### PR TITLE
Changed StrictMapping to Enum

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -126,10 +126,15 @@ The **GetColumnNames()** method can be used to retrieve the list of column names
 	var columnNames = excel.GetColumnNames("worksheetName");
 
 ## Strict Mapping
-Set the **StrictMapping** property to true to confirm all the columns in the worksheet map to a property on the class being used. A **StrictMappingException** is thrown when not all the columns map to a class property.
+The **StrictMapping** property can be set to: 
+* 'WorksheetStrict' in order to enforce all worksheet columns are mapped to a class property.
+* 'ClassStrict' to enforce all class properties are mapped to a to a worksheet column.
+* 'Both' to enforce all worksheet columns map to a class property and vice versa.
+  
+The implied default StrictMapping value is 'None'. A **StrictMappingException** is thrown when the specified mapping condition isn't satisified.
 
 	var excel = new ExcelQueryFactory("excelFileName");
-	excel.StrictMapping = true;
+	excel.StrictMapping = StrictMappingType.Both;
 
 ## Manually setting the database engine
 LinqToExcel can use the Jet or Ace database engine, and it automatically determines the database engine to use by the file extension. You can manually set the database engine with the **DatabaseEngine** property

--- a/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
+++ b/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
@@ -7,6 +7,8 @@ using LinqToExcel.Domain;
 
 namespace LinqToExcel.Tests
 {
+    using LinqToExcel.Query;
+
     [Author("Paul Yoder", "paulyoder@gmail.com")]
     [FixtureCategory("Unit")]
     [TestFixture]
@@ -115,32 +117,134 @@ namespace LinqToExcel.Tests
 
         [Test]
         [ExpectedException(typeof(StrictMappingException), "'City' property is not mapped to a column")]
-        public void StrictMapping_throws_StrictMappingException_when_property_is_not_mapped_to_column()
+        public void StrictMapping_ClassStrict_throws_StrictMappingException_when_property_is_not_mapped_to_column()
         {
             var excel = new ExcelQueryFactory(_excelFileName);
-            excel.StrictMapping = true;
+            excel.StrictMapping = StrictMappingType.ClassStrict;
+            var companies = (from x in excel.Worksheet<CompanyWithCity>()
+                             select x).ToList();
+        }
+
+        [Test]
+        public void StrictMapping_ClassStrict_with_additional_unused_worksheet_columns_doesnt_throw_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.StrictMapping = StrictMappingType.ClassStrict;
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<CompanyNullable>()
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+        }
+
+        [Test]
+        [ExpectedException(typeof(StrictMappingException), "'City' column is not mapped to a property")]
+        public void StrictMapping_WorksheetStrict_throws_StrictMappingException_when_column_is_not_mapped_to_property()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.StrictMapping = StrictMappingType.WorksheetStrict;
+            var companies = (from x in excel.Worksheet<Company>("Null Dates")
+                             select x).ToList();
+        }
+
+        [Test]
+        public void StrictMapping_WorksheetStrict_with_additional_unused_class_properties_doesnt_throw_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.StrictMapping = StrictMappingType.WorksheetStrict;
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<CompanyWithCity>()
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+        }
+
+        [Test]
+        [ExpectedException(typeof(StrictMappingException), "'City' property is not mapped to a column")]
+        public void StrictMapping_Both_throws_StrictMappingException_when_property_is_not_mapped_to_column()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.StrictMapping = StrictMappingType.Both;
             var companies = (from x in excel.Worksheet<CompanyWithCity>()
                              select x).ToList();
         }
 
         [Test]
         [ExpectedException(typeof(StrictMappingException), "'City' column is not mapped to a property")]
-        public void StrictMapping_throws_StrictMappingException_when_column_is_not_mapped_to_property()
+        public void StrictMapping_Both_throws_StrictMappingException_when_column_is_not_mapped_to_property()
         {
             var excel = new ExcelQueryFactory(_excelFileName);
-            excel.StrictMapping = true;
+            excel.StrictMapping = StrictMappingType.Both;
             var companies = (from x in excel.Worksheet<Company>("Null Dates")
                              select x).ToList();
         }
 
         [Test]
-        public void StrictMapping_with_column_mappings_doesnt_throw_exception()
+        public void StrictMapping_Both_with_column_mappings_doesnt_throw_exception()
         {
             var excel = new ExcelQueryFactory(_excelFileName);
-            excel.StrictMapping = true;
+            excel.StrictMapping = StrictMappingType.Both;
             excel.AddMapping<Company>(x => x.IsActive, "Active");
 
             var companies = (from c in excel.Worksheet<Company>("More Companies")
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+        }
+
+        [Test]
+        public void StrictMapping_None_with_additional_worksheet_column_doesnt_throw_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.StrictMapping = StrictMappingType.None;
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<Company>("Null Dates")
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+        }
+
+        [Test]
+        public void StrictMapping_None_with_additional_class_properties_doesnt_throw_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.StrictMapping = StrictMappingType.None;
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<CompanyWithCity>()
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+        }
+
+        [Test]
+        public void StrictMapping_Not_Explicitly_Set_with_additional_worksheet_column_doesnt_throw_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<Company>("Null Dates")
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+        }
+
+        [Test]
+        public void StrictMapping_Not_Explicitly_Set_with_additional_class_properties_doesnt_throw_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<CompanyWithCity>()
                              where c.Name == "ACME"
                              select c).ToList();
 

--- a/src/LinqToExcel/ExcelQueryFactory.cs
+++ b/src/LinqToExcel/ExcelQueryFactory.cs
@@ -19,7 +19,7 @@ namespace LinqToExcel
         /// <summary>
         /// Confirms all the worksheet columns are mapped to a property, and if not, throws a StrictMappingException
         /// </summary>
-        public bool StrictMapping { get; set; }
+        public StrictMappingType? StrictMapping { get; set; }
 
         /// <summary>
         /// Sets the database engine to use 

--- a/src/LinqToExcel/IExcelQueryFactory.cs
+++ b/src/LinqToExcel/IExcelQueryFactory.cs
@@ -16,7 +16,7 @@ namespace LinqToExcel
         /// <summary>
         /// Confirms all the worksheet columns are mapped to a property, and if not, throws a StrictMappingException
         /// </summary>
-        bool StrictMapping { get; set; }
+        StrictMappingType? StrictMapping { get; set; }
 
         /// <summary>
         /// Sets the database engine to use (spreadsheets ending in xlsx, xlsm, xlsb will always use the Ace engine)

--- a/src/LinqToExcel/LinqToExcel.csproj
+++ b/src/LinqToExcel/LinqToExcel.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Query\ExcelUtilities.cs" />
     <Compile Include="Query\ProjectorBuildingExpressionTreeVisitor.cs" />
     <Compile Include="Query\ResultObjectMapping.cs" />
+    <Compile Include="Query\StrictMappingType.cs" />
     <Compile Include="Query\WhereClauseExpressionTreeVisitor.cs" />
     <Compile Include="Query\SqlGeneratorQueryModelVisitor.cs" />
     <Compile Include="Query\SqlParts.cs" />

--- a/src/LinqToExcel/Query/ExcelQueryArgs.cs
+++ b/src/LinqToExcel/Query/ExcelQueryArgs.cs
@@ -17,7 +17,7 @@ namespace LinqToExcel.Query
         internal string StartRange { get; set; }
         internal string EndRange { get; set; }
         internal bool NoHeader { get; set; }
-        internal bool StrictMapping { get; set; }
+        internal StrictMappingType? StrictMapping { get; set; }
 
         internal ExcelQueryArgs()
             : this(new ExcelQueryConstructorArgs() { DatabaseEngine = ExcelUtilities.DefaultDatabaseEngine() })
@@ -29,7 +29,7 @@ namespace LinqToExcel.Query
             DatabaseEngine = args.DatabaseEngine;
             ColumnMappings = args.ColumnMappings ?? new Dictionary<string, string>();
             Transformations = args.Transformations ?? new Dictionary<string, Func<string, object>>();
-            StrictMapping = args.StrictMapping;
+            StrictMapping = args.StrictMapping ?? StrictMappingType.None;
         }
 
         public override string ToString()

--- a/src/LinqToExcel/Query/ExcelQueryConstructorArgs.cs
+++ b/src/LinqToExcel/Query/ExcelQueryConstructorArgs.cs
@@ -12,6 +12,6 @@ namespace LinqToExcel.Query
         internal DatabaseEngine DatabaseEngine { get; set; }
         internal Dictionary<string, string> ColumnMappings { get; set; }
         internal Dictionary<string, Func<string, object>> Transformations { get; set; }
-        internal bool StrictMapping { get; set; }
+        internal StrictMappingType? StrictMapping { get; set; }
     }
 }

--- a/src/LinqToExcel/Query/ExcelQueryExecutor.cs
+++ b/src/LinqToExcel/Query/ExcelQueryExecutor.cs
@@ -264,8 +264,8 @@ namespace LinqToExcel.Query
             var results = new List<object>();
             var fromType = queryModel.MainFromClause.ItemType;
             var props = fromType.GetProperties();
-            if (_args.StrictMapping)
-                ConfirmStrictMapping(columns, props);
+            if (_args.StrictMapping.Value != StrictMappingType.None)
+                this.ConfirmStrictMapping(columns, props, _args.StrictMapping.Value);
 
             while (data.Read())
             {
@@ -283,20 +283,27 @@ namespace LinqToExcel.Query
             return results.AsEnumerable();
         }
 
-        private void ConfirmStrictMapping(IEnumerable<string> columns, PropertyInfo[] properties)
+        private void ConfirmStrictMapping(IEnumerable<string> columns, PropertyInfo[] properties, StrictMappingType strictMappingType)
         {
             var propertyNames = properties.Select(x => x.Name);
-            foreach (var column in columns)
+            if (strictMappingType == StrictMappingType.ClassStrict || strictMappingType == StrictMappingType.Both)
             {
-                if (!propertyNames.Contains(column) &&
-                    ColumnIsNotMapped(column))
-                    throw new StrictMappingException("'{0}' column is not mapped to a property", column);
+                foreach (var propertyName in propertyNames)
+                {
+                    if (!columns.Contains(propertyName) &&
+                        PropertyIsNotMapped(propertyName))
+                        throw new StrictMappingException("'{0}' property is not mapped to a column", propertyName);
+                }
             }
-            foreach (var propertyName in propertyNames)
+
+            if (strictMappingType == StrictMappingType.WorksheetStrict || strictMappingType == StrictMappingType.Both)
             {
-                if (!columns.Contains(propertyName) &&
-                    PropertyIsNotMapped(propertyName))
-                    throw new StrictMappingException("'{0}' property is not mapped to a column", propertyName);
+                foreach (var column in columns)
+                {
+                    if (!propertyNames.Contains(column) &&
+                        ColumnIsNotMapped(column))
+                        throw new StrictMappingException("'{0}' column is not mapped to a property", column);
+                }
             }
         }
 

--- a/src/LinqToExcel/Query/StrictMappingType.cs
+++ b/src/LinqToExcel/Query/StrictMappingType.cs
@@ -1,0 +1,28 @@
+﻿namespace LinqToExcel.Query
+{
+    /// <summary>
+    /// Class property and worksheet mapping enforcemment type.
+    /// </summary>
+    public enum StrictMappingType
+    {
+        /// <summary>
+        /// All worksheet columns must map to a class property; all class properties must map to a worksheet columm.
+        /// </summary>
+        Both,
+
+        /// <summary>
+        /// All class properties must map to a worksheet column; other worksheet columns are ignored.
+        /// </summary>
+        ClassStrict,
+
+        /// <summary>
+        /// No checks are made to enforce worksheet column or class property mappings.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// All worksheet columns must map to a class property; other class properties are ignored.
+        /// </summary>
+        WorksheetStrict
+    }
+}


### PR DESCRIPTION
Updated the **StrictMapping** property from a Boolean to a nullable Enum to allow the consumer finer-grained control of mapping enforcement.  This grew out from a need to enforce that a class had mappings for all properties, but to also disregard any other Excel worksheet columns.  The StrictMapping Enum values have been defined as:
- 'WorksheetStrict' in order to enforce all worksheet columns are mapped to a class property.
- 'ClassStrict' to enforce all class properties are mapped to a to a worksheet column.
- 'Both' to enforce all worksheet columns map to a class property and vice versa. (this behaves exactly like the previous StrictMapping = true option)

The implied default StrictMapping value is 'None' which behaves as if the previous StrictMapping Boolean property was set to false or not set at all.  Since this property is nullable, this will be a transparent change for consumers that didn't previously set the StrictMapping property.

Positive and negative unit tests were added to cover all four Enum values, plus additional tests covering the value not being set.  The Readme.markdown was also updated to reflect the enhanced options for the StrictMapping property.
