### PR TITLE
Refactored IEnumerable<> calls to use 'yield return' for streaming

### DIFF
--- a/src/LinqToExcel/Extensions/CommonExtensions.cs
+++ b/src/LinqToExcel/Extensions/CommonExtensions.cs
@@ -52,10 +52,8 @@ namespace LinqToExcel.Extensions
 
         public static IEnumerable<TResult> Cast<TResult>(this IEnumerable<object> list, Func<object, TResult> caster)
         {
-            var results = new List<TResult>();
             foreach (var item in list)
-                results.Add(caster(item));
-            return results;
+                yield return caster(item);
         }
 
         public static IEnumerable<TResult> Cast<TResult>(this IEnumerable<object> list)


### PR DESCRIPTION
Refactored IEnumerable<> calls to use 'yield return' for streaming data vs caching it all in a List<> and then returning it. This is the only way to use LinqToExcel w/ large files (> 1gb or so).
