### PR TITLE
Add method to get worksheet names in the same order they appear in excel (for review/comments only)

### DIFF
--- a/src/LinqToExcel/ExcelQueryFactory.cs
+++ b/src/LinqToExcel/ExcelQueryFactory.cs
@@ -140,6 +140,17 @@ namespace LinqToExcel
         }
 
         /// <summary>
+        /// Returns a list of worksheet names that the spreadsheet contains, in the same order that they would appear in excel
+        /// </summary>
+        public IEnumerable<string> GetWorksheetNamesOrdered()
+        {
+            if (String.IsNullOrEmpty(FileName))
+                throw new NullReferenceException("FileName property is not set");
+
+            return ExcelUtilities.GetWorksheetNamesOrdered(FileName);
+        }
+
+        /// <summary>
         /// Returns a list of columns names that a worksheet contains
         /// </summary>
         /// <param name="worksheetName">Worksheet name to get the list of column names from</param>

--- a/src/LinqToExcel/LinqToExcel.csproj
+++ b/src/LinqToExcel/LinqToExcel.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LinqToExcel</RootNamespace>
     <AssemblyName>LinqToExcel</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
@@ -31,6 +31,7 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -42,6 +43,7 @@
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
     <DocumentationFile>bin\Debug\LinqToExcel.xml</DocumentationFile>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>
@@ -51,6 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <PlatformTarget>x86</PlatformTarget>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -62,7 +65,7 @@
     <Reference Include="log4net">
       <HintPath>..\..\lib\Log4Net\log4net.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.DebuggerVisualizers, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Remotion, Version=1.13.52.2, Culture=neutral, PublicKeyToken=0669cf0452175907, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\Remotion\Remotion.dll</HintPath>
@@ -75,6 +78,7 @@
     <Reference Include="System.Core">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>


### PR DESCRIPTION
This provides a method GetWorksheetNamesOrdered() to return the worksheet names in the same order as they would appear in excel.

Works by extracting the contents of the excel file, finding the XML file containing the worksheet names and parsing the XML contents of that file. I found the necessary information about the xlsx file format from this stack overflow answer:
http://stackoverflow.com/a/19930386/2617732

Using the test excel files, the new method works fine with the xlsm and xlsx files. It also works with csv by returning an empty list. It doesn't work for the xls and xlsb files as they have a different format. If anybody knows where the same worksheet information could be found within an xls file, please comment on here.

Notes:
1. Requires the project to use v4.5 .net framework
2. Requires a reference to System.IO.Compression
3. This doesn't have any dependencies within this project so even if its unsuitable for merging, its still potentially useful as a standalone function i.e. to offer a workaround to people that need the ordering of worksheets.
