### PR TITLE
Fix issue where NULL constant expressions in 'where' LINQ expression throws InvalidCastException

### DIFF
--- a/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
+++ b/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
@@ -328,5 +328,25 @@ namespace LinqToExcel.Tests
 
             Assert.AreEqual(" White Space On Both Sides ", companies[2].Name);
         }
+
+        [Test]
+        public void Null_ConstantExpression_in_where_expression_should_not_throw_exception()
+        {
+            // The C# 6 compiler made some changes to the expression tree output.
+            // This changes are largely transparent to consumers if they adhere
+            // to the Liskov Substitution Principle.  This test is to specifically
+            // address a bug in which the code didn't allow the derived TypedConstantExpression
+            // to be substituted for a ConstantExpression.  This resulted in a downstream InvalidCastException
+            // when the LinqToExcel invoked Converter.ChangeType since TypedConstantExpression
+            // does not implement IConvertible.
+            var excel = new ExcelQueryFactory(_excelFileName);
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<CompanyNullable>()
+                             where c.Name != null
+                             select c).ToList();
+
+            Assert.IsNotNull(companies);
+        }
     }
 }

--- a/src/LinqToExcel/Extensions/CommonExtensions.cs
+++ b/src/LinqToExcel/Extensions/CommonExtensions.cs
@@ -80,8 +80,8 @@ namespace LinqToExcel.Extensions
 
         public static bool IsNullValue(this Expression exp)
         {
-            return ((exp is ConstantExpression) &&
-                (exp.Cast<ConstantExpression>().Value == null));
+            var constantExpression = exp as ConstantExpression;
+            return constantExpression != null && constantExpression.Value == null;
         }
 
         public static string RegexReplace(this string source, string regex, string replacement)


### PR DESCRIPTION
The C# 6 compiler made some changes to the expression tree output.  These changes are largely transparent to consumers if they adhere to the Liskov Substitution Principle.  In this case, LinqToExcel doesn't allow the derived TypedConstantExpression to be substituted for a ConstantExpression.  This results in a downstream InvalidCastException when the LinqToExcel invokes Converter.ChangeType since TypedConstantExpression does not implement IConvertible.

This pull request addresses the issue by allowing TypedConstantExpression to be substituted for ConstantExpression.  The footprint of the change is very small and the risk of causing regression issues is next to nothing.  I've tested the fix and it works as expected.
### Minimal, Complete, and Verifiable example

Below is a code snippet that will reproduce the issue when the code is compiled with the C# 6 compiler.  The code throws an InvalidCastException:

`var companies = (from c in excel.Worksheet<Company>()
                             where c.Name != null
                             select c).ToList();`
### Error Message

Object must implement IConvertible.
### Stack trace

`at System.Convert.ChangeType(Object value, Type conversionType, IFormatProvider provider)
   at System.Convert.ChangeType(Object value, Type conversionType)
   at LinqToExcel.Extensions.CommonExtensions.Cast(Object object, Type castType)
   at LinqToExcel.Extensions.CommonExtensions.Cast[T](Object object)
   at LinqToExcel.Extensions.CommonExtensions.IsNullValue(Expression exp)
   at LinqToExcel.Query.WhereClauseExpressionTreeVisitor.VisitBinaryExpression(BinaryExpression bExp)
   at Remotion.Data.Linq.Parsing.ExpressionTreeVisitor.VisitExpression(Expression expression)
   at LinqToExcel.Query.SqlGeneratorQueryModelVisitor.VisitWhereClause(WhereClause whereClause, QueryModel queryModel, Int32 index)
   at Remotion.Data.Linq.Clauses.WhereClause.Accept(IQueryModelVisitor visitor, QueryModel queryModel, Int32 index)
   at Remotion.Data.Linq.QueryModelVisitorBase.VisitBodyClauses(ObservableCollection`1 bodyClauses, QueryModel queryModel)
   at LinqToExcel.Query.SqlGeneratorQueryModelVisitor.VisitBodyClauses(ObservableCollection`1 bodyClauses, QueryModel queryModel)
   at LinqToExcel.Query.SqlGeneratorQueryModelVisitor.VisitQueryModel(QueryModel queryModel)
   at LinqToExcel.Query.ExcelQueryExecutor.GetSqlStatement(QueryModel queryModel)
   at LinqToExcel.Query.ExcelQueryExecutor.ExecuteCollection[T](QueryModel queryModel)
   at LinqToExcel.Query.ExcelQueryExecutor.ExecuteSingle[T](QueryModel queryModel, Boolean returnDefaultWhenEmpty)
   at LinqToExcel.Query.ExcelQueryExecutor.ExecuteScalar[T](QueryModel queryModel)
   at Remotion.Data.Linq.Clauses.StreamedData.StreamedScalarValueInfo.ExecuteScalarQueryModel[T](QueryModel queryModel, IQueryExecutor executor)
   at Remotion.Data.Linq.Clauses.StreamedData.StreamedScalarValueInfo.ExecuteQueryModel(QueryModel queryModel, IQueryExecutor executor)
   at Remotion.Data.Linq.QueryModel.Execute(IQueryExecutor executor)
   at Remotion.Data.Linq.QueryProviderBase.Execute[TResult](Expression expression)`

~
Nice library by the way.  Thanks Paul.
