### PR TITLE
Fix for KB4041678 KB4041681 by switching the default engine to ACE 12

### DIFF
--- a/src/LinqToExcel.Tests/ConnectionString_UnitTests.cs
+++ b/src/LinqToExcel.Tests/ConnectionString_UnitTests.cs
@@ -31,7 +31,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.Jet.OLEDB.4.0;Data Source={0};Extended Properties=""Excel 8.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
                 "spreadsheet.xls");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -48,7 +48,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.Jet.OLEDB.4.0;Data Source={0};Extended Properties=""Excel 8.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.xls");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -97,7 +97,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.Jet.OLEDB.4.0;Data Source={0};Extended Properties=""Excel 8.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
                 "spreadsheet.dlo");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -114,7 +114,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.Jet.OLEDB.4.0;Data Source={0};Extended Properties=""Excel 8.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.dlo");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -357,7 +357,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.Jet.OLEDB.4.0;Data Source={0};Extended Properties=""Excel 8.0;HDR=NO;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=NO;IMEX=1""",
                 "spreadsheet.xls");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -374,7 +374,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.Jet.OLEDB.4.0;Data Source={0};Extended Properties=""Excel 8.0;HDR=NO;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=NO;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.xls");
             Assert.AreEqual(expected, GetConnectionString());
         }

--- a/src/LinqToExcel.sln
+++ b/src/LinqToExcel.sln
@@ -1,9 +1,13 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqToExcel", "LinqToExcel\LinqToExcel.csproj", "{08F80D96-5387-4406-B88B-DCC0CB661702}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinqToExcel.Tests", "LinqToExcel.Tests\LinqToExcel.Tests.csproj", "{195B956A-8029-44FD-9518-C04F5280611F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "test-kb4041678", "test-kb4041678\test-kb4041678.csproj", "{37387A3F-3161-406B-816C-03F4093B1A9B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,6 +23,10 @@ Global
 		{195B956A-8029-44FD-9518-C04F5280611F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{195B956A-8029-44FD-9518-C04F5280611F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{195B956A-8029-44FD-9518-C04F5280611F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{37387A3F-3161-406B-816C-03F4093B1A9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{37387A3F-3161-406B-816C-03F4093B1A9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{37387A3F-3161-406B-816C-03F4093B1A9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{37387A3F-3161-406B-816C-03F4093B1A9B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/LinqToExcel/Query/ExcelUtilities.cs
+++ b/src/LinqToExcel/Query/ExcelUtilities.cs
@@ -47,18 +47,9 @@ namespace LinqToExcel.Query
             }
             else
             {
-                if (args.DatabaseEngine == DatabaseEngine.Jet)
-                {
-                    connString = string.Format(
-                        @"Provider=Microsoft.Jet.OLEDB.4.0;Data Source={0};Extended Properties=""Excel 8.0;HDR=YES;IMEX=1""",
-                        args.FileName);
-                }
-                else
-                {
-                    connString = string.Format(
-                        @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
-                        args.FileName);
-                }
+                connString = string.Format(
+                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
+                    args.FileName);
             }
 
             if (args.NoHeader)


### PR DESCRIPTION
Switching the default engine to ACE 12, since according to wikipedia, ACE12 supports every format that OLEDB 4 does [https://en.wikipedia.org/wiki/Microsoft_Jet_Database_Engine](url)

Tests updated and all passed