### PR TITLE
#114 Add 'ExcelIgnore' Attribute.

### DIFF
--- a/src/LinqToExcel.Tests/CompanyIgnoreIsActive.cs
+++ b/src/LinqToExcel.Tests/CompanyIgnoreIsActive.cs
@@ -1,0 +1,10 @@
+﻿using LinqToExcel.Attributes;
+
+namespace LinqToExcel.Tests
+{
+    class CompanyIgnoreIsActive : Company
+    {
+        [ExcelIgnore]
+        new public bool IsActive { get; set; }
+    }
+}

--- a/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
+++ b/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
@@ -169,6 +169,20 @@ namespace LinqToExcel.Tests
         }
 
         [Test]
+        public void StrictMapping_ClassStrict_with_ignore_attribute_doesnt_throw_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName, new LogManagerFactory());
+            excel.StrictMapping = StrictMappingType.ClassStrict;
+
+            var companies = (from c in excel.Worksheet<CompanyIgnoreIsActive>("More Companies")
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+        }
+
+
+        [Test]
         public void StrictMapping_WorksheetStrict_throws_StrictMappingException_when_column_is_not_mapped_to_property()
         {
             var excel = new ExcelQueryFactory(_excelFileName, new LogManagerFactory());
@@ -193,6 +207,21 @@ namespace LinqToExcel.Tests
 
             Assert.AreEqual(1, companies.Count);
         }
+
+        [Test]
+        public void StrictMapping_WorksheetStrict_with_ignore_attribute_throws_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName, new LogManagerFactory());
+            excel.StrictMapping = StrictMappingType.WorksheetStrict;
+
+            var companies = (from c in excel.Worksheet<CompanyIgnoreIsActive>("More Companies")
+                             where c.Name == "ACME"
+                             select c);
+            Assert.That(() => companies.ToList(),
+            Throws.TypeOf<StrictMappingException>(), "'Active' column is not mapped to a property");
+
+        }
+
 
         [Test]
         public void StrictMapping_Both_throws_StrictMappingException_when_property_is_not_mapped_to_column()
@@ -224,6 +253,19 @@ namespace LinqToExcel.Tests
             excel.AddMapping<Company>(x => x.IsActive, "Active");
 
             var companies = (from c in excel.Worksheet<Company>("More Companies")
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+        }
+
+        [Test]
+        public void StrictMapping_Both_with_ignore_attribute_doesnt_throw_exception()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName, new LogManagerFactory());
+            excel.StrictMapping = StrictMappingType.Both;
+
+            var companies = (from c in excel.Worksheet<CompanyIgnoreIsActive>("Sheet1")
                              where c.Name == "ACME"
                              select c).ToList();
 

--- a/src/LinqToExcel.Tests/LinqToExcel.Tests.csproj
+++ b/src/LinqToExcel.Tests/LinqToExcel.Tests.csproj
@@ -90,6 +90,7 @@
     <Compile Include="ColumnMappings_IntegrationTests.cs" />
     <Compile Include="ColumnMappings_SQLStatements_UnitTests.cs" />
     <Compile Include="CompanyNullable.cs" />
+    <Compile Include="CompanyIgnoreIsActive.cs" />
     <Compile Include="CompanyWithColumnAnnotations.cs" />
     <Compile Include="CompanyWithCity.cs" />
     <Compile Include="ConfiguredWorksheetName_SQLStatements_UnitTests.cs" />

--- a/src/LinqToExcel/Attributes/ExcelIgnoreAttribute.cs
+++ b/src/LinqToExcel/Attributes/ExcelIgnoreAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace LinqToExcel.Attributes
+{
+    /// <summary>
+    /// Ignores attribute during column map creation. Allows property to be safely ignored
+    /// when using StrictMappingType
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property, Inherited = true, AllowMultiple = false)]
+    public sealed class ExcelIgnore : Attribute
+    {
+        public ExcelIgnore()
+        { }
+    }
+}

--- a/src/LinqToExcel/LinqToExcel.csproj
+++ b/src/LinqToExcel/LinqToExcel.csproj
@@ -82,6 +82,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Attributes\ExcelIgnoreAttribute.cs" />
     <Compile Include="Attributes\ExcelColumnAttribute.cs" />
     <Compile Include="Domain\Cell.cs" />
     <Compile Include="Domain\RowNoHeader.cs" />

--- a/src/LinqToExcel/Query/ExcelQueryExecutor.cs
+++ b/src/LinqToExcel/Query/ExcelQueryExecutor.cs
@@ -13,6 +13,7 @@ using System.Text.RegularExpressions;
 using System.Text;
 using LinqToExcel.Domain;
 using LinqToExcel.Logging;
+using LinqToExcel.Attributes;
 
 namespace LinqToExcel.Query
 {
@@ -372,7 +373,10 @@ namespace LinqToExcel.Query
 
         private void ConfirmStrictMapping(IEnumerable<string> columns, PropertyInfo[] properties, StrictMappingType strictMappingType)
         {
-            var propertyNames = properties.Select(x => x.Name);
+
+            var propertyNames = properties
+                .Where(x => (ExcelIgnore)Attribute.GetCustomAttribute(x, typeof(ExcelIgnore)) == null)
+                .Select(x => x.Name);
             if (strictMappingType == StrictMappingType.ClassStrict || strictMappingType == StrictMappingType.Both)
             {
                 foreach (var propertyName in propertyNames)

--- a/src/LinqToExcel/Query/ExcelQueryable.cs
+++ b/src/LinqToExcel/Query/ExcelQueryable.cs
@@ -23,7 +23,9 @@ namespace LinqToExcel.Query
             foreach (var property in typeof(T).GetProperties())
             {
                 ExcelColumnAttribute att = (ExcelColumnAttribute)Attribute.GetCustomAttribute(property, typeof(ExcelColumnAttribute));
-                if (att != null && !args.ColumnMappings.ContainsKey(property.Name))
+                ExcelIgnore ignore = (ExcelIgnore)Attribute.GetCustomAttribute(property, typeof(ExcelIgnore));
+
+                if (att != null && !args.ColumnMappings.ContainsKey(property.Name) && (ignore == null))
                 {
                     args.ColumnMappings.Add(property.Name, att.ColumnName);
                 }


### PR DESCRIPTION
Ignores attribute during column map creation. Allows property to be safely ignore when using StrictMappingType. Added 3 new test cases for the attribute.