### PR TITLE
Allow connstring suppression of TransactionScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,3 +291,18 @@ Set the `ReadOnly` property to true to open the file in readonly mode. The defau
 var excel = new ExcelQueryFactory("excelFileName");
 excel.ReadOnly = true;
 ```
+
+## Suppressing TransactionScope
+
+By default, the OLE DB Provider will try to enlist in an open TransactionScope and will fail because Excel does not
+allow for transactions. To avoid this behavior and opt out of TransactionScope for the connection, set `OleDbServices`
+to `AllServicesExceptPoolingAndAutoEnlistment`.
+
+See [Pooling in the Microsoft Data Access
+Components](https://msdn.microsoft.com/en-us/library/ms810829.aspx#Troubleshooting%20MDAC%20Pooling) for more
+information.
+
+```c#
+var excel = new ExcelQueryFactory("excelFileName");
+excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
+```

--- a/src/LinqToExcel.Tests/ConnectionString_UnitTests.cs
+++ b/src/LinqToExcel.Tests/ConnectionString_UnitTests.cs
@@ -33,7 +33,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             string expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
                 "spreadsheet.xls"
             );
 
@@ -52,7 +52,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             string expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.xls"
             );
 
@@ -70,7 +70,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
                 "spreadsheet.xls");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -87,7 +87,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.xls");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -101,7 +101,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             string expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
                 "spreadsheet.dlo"
             );
 
@@ -120,7 +120,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             string expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.dlo"
             );
 
@@ -138,7 +138,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
                 "spreadsheet.dlo");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -155,7 +155,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.dlo");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -170,7 +170,7 @@ namespace LinqToExcel.Tests
             catch (OleDbException) { }
 
             string expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1""",
                 @"C:\Desktop"
             );
 
@@ -189,7 +189,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             string expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 @"C:\Desktop"
             );
 
@@ -207,7 +207,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1""",
                 @"C:\Desktop");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -224,7 +224,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 @"C:\Desktop");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -238,7 +238,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1""",
                 "spreadsheet.xlsx");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -255,7 +255,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.xlsx");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -269,7 +269,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1""",
                 "spreadsheet.xlsm");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -283,7 +283,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
                 "spreadsheet.xlsb");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -300,7 +300,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             var expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.xlsb");
             Assert.AreEqual(expected, GetConnectionString());
         }
@@ -315,7 +315,7 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             string expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=NO;IMEX=1""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=NO;IMEX=1""",
                 "spreadsheet.xls"
             );
 
@@ -334,7 +334,82 @@ namespace LinqToExcel.Tests
             try { companies.GetEnumerator(); }
             catch (OleDbException) { }
             string expected = string.Format(
-                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=NO;IMEX=1;READONLY=TRUE""",
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-1;Extended Properties=""Excel 12.0;HDR=NO;IMEX=1;READONLY=TRUE""",
+                "spreadsheet.xls"
+            );
+
+            Assert.AreEqual(expected, GetConnectionString());
+        }
+
+        [Test]
+        public void xlsx_readonly_connection_string_suppress_transactionscope()
+        {
+            var excel = new ExcelQueryFactory("spreadsheet.xlsx", new LogManagerFactory());
+            excel.ReadOnly = true;
+            excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
+
+            var companies = from c in excel.Worksheet<Company>()
+                            select c;
+
+            try { companies.GetEnumerator(); }
+            catch (OleDbException) { }
+            var expected = string.Format(
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-4;Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1;READONLY=TRUE""",
+                "spreadsheet.xlsx");
+            Assert.AreEqual(expected, GetConnectionString());
+        }
+
+
+        [Test]
+        public void xlsb_readonly_connection_string_suppress_transactionscope()
+        {
+            var excel = new ExcelQueryFactory("spreadsheet.xlsb", new LogManagerFactory());
+            excel.ReadOnly = true;
+            excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
+
+            var companies = from c in excel.Worksheet<Company>()
+                            select c;
+
+            try { companies.GetEnumerator(); }
+            catch (OleDbException) { }
+            var expected = string.Format(
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-4;Extended Properties=""Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                "spreadsheet.xlsb");
+            Assert.AreEqual(expected, GetConnectionString());
+        }
+
+        [Test]
+        public void csv_readonly_with_Ace_DatabaseEngine_connection_string_suppress_transactionscope()
+        {
+            var excel = new ExcelQueryFactory(@"C:\Desktop\spreadsheet.csv", new LogManagerFactory());
+            excel.ReadOnly = true;
+            excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
+
+            var companies = from c in excel.Worksheet()
+                            select c;
+
+            try { companies.GetEnumerator(); }
+            catch (OleDbException) { }
+            var expected = string.Format(
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-4;Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1;READONLY=TRUE""",
+                @"C:\Desktop");
+            Assert.AreEqual(expected, GetConnectionString());
+        }
+
+        [Test]
+        public void no_header_readonly_connection_string_suppress_transactionscope()
+        {
+            var excel = new ExcelQueryFactory("spreadsheet.xls", new LogManagerFactory());
+            excel.ReadOnly = true;
+            excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
+
+            var companies = from c in excel.WorksheetNoHeader()
+                            select c;
+
+            try { companies.GetEnumerator(); }
+            catch (OleDbException) { }
+            string expected = string.Format(
+                @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services=-4;Extended Properties=""Excel 12.0;HDR=NO;IMEX=1;READONLY=TRUE""",
                 "spreadsheet.xls"
             );
 

--- a/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
+++ b/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
@@ -8,6 +8,7 @@ using LinqToExcel.Domain;
 namespace LinqToExcel.Tests
 {
     using LinqToExcel.Query;
+    using System.Transactions;
 
     [Author("Paul Yoder", "paulyoder@gmail.com")]
     [Category("Unit")]
@@ -365,6 +366,33 @@ namespace LinqToExcel.Tests
                              select c).ToList();
 
             Assert.IsNotNull(companies);
+        }
+
+        [Test]
+        public void TransactionScope_causes_exception_when_not_suppressed()
+        {
+            using (var trans = new TransactionScope())
+            {
+                var excel = new ExcelQueryFactory(_excelFileWithBuiltinWorksheets, new LogManagerFactory());
+
+                Assert.Throws<InvalidOperationException>(() => excel.GetWorksheetNames());
+            }
+        }
+
+        [Test]
+        public void TransactionScope_is_suppressed_when_requested()
+        {
+            using (var trans = new TransactionScope())
+            {
+                var excel = new ExcelQueryFactory(_excelFileWithBuiltinWorksheets, new LogManagerFactory());
+                excel.OleDbServices = OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
+
+                var worksheetNames = excel.GetWorksheetNames();
+
+                Assert.AreEqual(
+                    "AutoFiltered, ColumnMappings, MoreCompanies, NullCells, Paul's Worksheet, Sheet1",
+                    string.Join(", ", worksheetNames.ToArray()), "TransactionScope was not suppressed");
+            }
         }
     }
 }

--- a/src/LinqToExcel.Tests/LinqToExcel.Tests.csproj
+++ b/src/LinqToExcel.Tests/LinqToExcel.Tests.csproj
@@ -49,6 +49,7 @@
     <None Include="ExcelFiles\NoHeader.xls">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <Reference Include="System.Transactions" />
     <None Update="ExcelFiles\WorksheetNames.xlsx">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/LinqToExcel/ExcelQueryFactory.cs
+++ b/src/LinqToExcel/ExcelQueryFactory.cs
@@ -46,6 +46,12 @@ namespace LinqToExcel
         /// </summary>
         public bool UsePersistentConnection { get; set; }
 
+        /// <summary>
+        /// Gets or sets the value of the OLE DB Services flag sent in the connection strings,
+        /// which among other features, can disable auto-enlistment in TransactionScopes.
+        /// </summary>
+        public OleDbServices OleDbServices { get; set; }
+
         public ExcelQueryFactory()
           : this(null, null) { }
 
@@ -68,6 +74,7 @@ namespace LinqToExcel
         public ExcelQueryFactory(string fileName, ILogManagerFactory logManagerFactory)
         {
             FileName = fileName;
+            OleDbServices = OleDbServices.AllServices;
 
             if (logManagerFactory != null) {
                _logManagerFactory = logManagerFactory;
@@ -148,7 +155,7 @@ namespace LinqToExcel
             if (String.IsNullOrEmpty(FileName))
                 throw new NullReferenceException("FileName property is not set");
 
-            return ExcelUtilities.GetWorksheetNames(FileName);
+            return ExcelUtilities.GetWorksheetNames(FileName, GetQueryArgs());
         }
 
         /// <summary>
@@ -159,7 +166,7 @@ namespace LinqToExcel
             if (String.IsNullOrEmpty(FileName))
                 throw new NullReferenceException("FileName property is not set");
 
-            return ExcelUtilities.GetNamedRanges(FileName);
+            return ExcelUtilities.GetNamedRanges(FileName, GetQueryArgs());
         }
 
         /// <summary>
@@ -171,7 +178,7 @@ namespace LinqToExcel
             if (String.IsNullOrEmpty(FileName))
                 throw new NullReferenceException("FileName property is not set");
 
-            return ExcelUtilities.GetNamedRanges(FileName, worksheetName);
+            return ExcelUtilities.GetNamedRanges(FileName, worksheetName, GetQueryArgs());
         }
 
         /// <summary>
@@ -183,7 +190,7 @@ namespace LinqToExcel
             if (String.IsNullOrEmpty(FileName))
                 throw new NullReferenceException("FileName property is not set");
 
-            return ExcelUtilities.GetColumnNames(worksheetName, FileName);
+            return ExcelUtilities.GetColumnNames(worksheetName, FileName, GetQueryArgs());
         }
 
         /// <summary>
@@ -196,7 +203,7 @@ namespace LinqToExcel
             if (String.IsNullOrEmpty(FileName))
                 throw new NullReferenceException("FileName property is not set");
 
-            return ExcelUtilities.GetColumnNames(worksheetName, namedRange, FileName);
+            return ExcelUtilities.GetColumnNames(worksheetName, namedRange, FileName, GetQueryArgs());
         }
 
         internal ExcelQueryConstructorArgs GetConstructorArgs()
@@ -209,8 +216,14 @@ namespace LinqToExcel
                 Transformations = _transformations,
                 UsePersistentConnection = UsePersistentConnection,
                 TrimSpaces = TrimSpaces,
-                ReadOnly = ReadOnly
+                ReadOnly = ReadOnly,
+                OleDbServices = OleDbServices,
             };
+        }
+
+        internal ExcelQueryArgs GetQueryArgs()
+        {
+            return new ExcelQueryArgs(GetConstructorArgs());
         }
 
         #endregion

--- a/src/LinqToExcel/Query/ExcelQueryArgs.cs
+++ b/src/LinqToExcel/Query/ExcelQueryArgs.cs
@@ -23,10 +23,38 @@ namespace LinqToExcel.Query
         internal bool UsePersistentConnection { get; set; }
 		internal OleDbConnection PersistentConnection { get; set; }
         internal TrimSpacesType TrimSpaces { get; set; }
+        internal OleDbServices OleDbServices { get; set; }
 
         internal ExcelQueryArgs()
             : this(new ExcelQueryConstructorArgs())
-        { }
+        {
+            OleDbServices = OleDbServices.AllServices;
+        }
+
+        /// <summary>
+        /// Copy constructor
+        /// </summary>
+        internal ExcelQueryArgs(ExcelQueryArgs orig) : this()
+        {
+            if (orig != null)
+            {
+                FileName = orig.FileName;
+                WorksheetName = orig.WorksheetName;
+                WorksheetIndex = orig.WorksheetIndex;
+                ColumnMappings = orig.ColumnMappings;
+                Transformations = orig.Transformations;
+                NamedRangeName = orig.NamedRangeName;
+                StartRange = orig.StartRange;
+                EndRange = orig.EndRange;
+                NoHeader = orig.NoHeader;
+                StrictMapping = orig.StrictMapping;
+                ReadOnly = orig.ReadOnly;
+                UsePersistentConnection = orig.UsePersistentConnection;
+                PersistentConnection = orig.PersistentConnection;
+                TrimSpaces = orig.TrimSpaces;
+                OleDbServices = orig.OleDbServices;
+            }
+        }
 
         internal ExcelQueryArgs(ExcelQueryConstructorArgs args)
         {
@@ -37,6 +65,7 @@ namespace LinqToExcel.Query
             UsePersistentConnection = args.UsePersistentConnection;
             TrimSpaces = args.TrimSpaces;
             ReadOnly = args.ReadOnly;
+            OleDbServices = args.OleDbServices;
         }
 
         public override string ToString()

--- a/src/LinqToExcel/Query/ExcelQueryConstructorArgs.cs
+++ b/src/LinqToExcel/Query/ExcelQueryConstructorArgs.cs
@@ -9,6 +9,11 @@ namespace LinqToExcel.Query
 {
     internal class ExcelQueryConstructorArgs
     {
+        public ExcelQueryConstructorArgs()
+        {
+            OleDbServices = OleDbServices.AllServices;
+        }
+
         internal string FileName { get; set; }
         internal Dictionary<string, string> ColumnMappings { get; set; }
         internal Dictionary<string, Func<string, object>> Transformations { get; set; }
@@ -16,5 +21,6 @@ namespace LinqToExcel.Query
         internal bool UsePersistentConnection { get; set; }
         internal TrimSpacesType TrimSpaces { get; set; }
         internal bool ReadOnly { get; set; }
+        internal OleDbServices OleDbServices { get; set; }
     }
 }

--- a/src/LinqToExcel/Query/ExcelUtilities.cs
+++ b/src/LinqToExcel/Query/ExcelUtilities.cs
@@ -20,26 +20,30 @@ namespace LinqToExcel.Query
                 fileNameLower.EndsWith("xlsm"))
             {
                 connString = string.Format(
-                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1""",
-                    args.FileName);
+                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services={1:d};Extended Properties=""Excel 12.0 Xml;HDR=YES;IMEX=1""",
+                    args.FileName,
+                    args.OleDbServices);
             }
             else if (fileNameLower.EndsWith("xlsb"))
             {
                 connString = string.Format(
-                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
-                    args.FileName);
+                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services={1:d};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
+                    args.FileName,
+                    args.OleDbServices);
             }
             else if (fileNameLower.EndsWith("csv"))
             {
                 connString = string.Format(
-                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1""",
-                    Path.GetDirectoryName(args.FileName));
+                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services={1:d};Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1""",
+                    Path.GetDirectoryName(args.FileName),
+                    args.OleDbServices);
             }
             else
             {
                 connString = string.Format(
-                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
-                    args.FileName);
+                    @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services={1:d};Extended Properties=""Excel 12.0;HDR=YES;IMEX=1""",
+                    args.FileName,
+                    args.OleDbServices);
             }
 
             if (args.NoHeader)
@@ -56,8 +60,9 @@ namespace LinqToExcel.Query
             return GetWorksheetNames(fileName, new ExcelQueryArgs());
         }
 
-        internal static IEnumerable<string> GetWorksheetNames(string fileName, ExcelQueryArgs args)
+        internal static IEnumerable<string> GetWorksheetNames(string fileName, ExcelQueryArgs origArgs)
         {
+            var args = new ExcelQueryArgs(origArgs);
             args.FileName = fileName;
             args.ReadOnly = true;
             return GetWorksheetNames(args);
@@ -139,7 +144,12 @@ namespace LinqToExcel.Query
 
         internal static IEnumerable<string> GetColumnNames(string worksheetName, string fileName)
         {
-            var args = new ExcelQueryArgs();
+            return GetColumnNames(worksheetName, fileName, new ExcelQueryArgs());
+        }
+
+        internal static IEnumerable<string> GetColumnNames(string worksheetName, string fileName, ExcelQueryArgs origArgs)
+        {
+            var args = new ExcelQueryArgs(origArgs);
             args.WorksheetName = worksheetName;
             args.FileName = fileName;
             return GetColumnNames(args);
@@ -147,7 +157,12 @@ namespace LinqToExcel.Query
 
         internal static IEnumerable<string> GetColumnNames(string worksheetName, string namedRange, string fileName)
         {
-            var args = new ExcelQueryArgs();
+            return GetColumnNames(worksheetName, namedRange, fileName, new ExcelQueryArgs());
+        }
+
+        internal static IEnumerable<string> GetColumnNames(string worksheetName, string namedRange, string fileName, ExcelQueryArgs origArgs)
+        {
+            var args = new ExcelQueryArgs(origArgs);
             args.WorksheetName = worksheetName;
             args.NamedRangeName = namedRange;
             args.FileName = fileName;
@@ -199,15 +214,17 @@ namespace LinqToExcel.Query
             return GetNamedRanges(fileName, new ExcelQueryArgs());
         }
 
-        internal static IEnumerable<string> GetNamedRanges(string fileName, ExcelQueryArgs args)
+        internal static IEnumerable<string> GetNamedRanges(string fileName, ExcelQueryArgs origArgs)
         {
+            var args = new ExcelQueryArgs(origArgs);
             args.FileName = fileName;
             args.ReadOnly = true;
             return GetNamedRanges(args);
         }
 
-        internal static IEnumerable<string> GetNamedRanges(string fileName, string worksheetName, ExcelQueryArgs args)
+        internal static IEnumerable<string> GetNamedRanges(string fileName, string worksheetName, ExcelQueryArgs origArgs)
         {
+            var args = new ExcelQueryArgs(origArgs);
             args.FileName = fileName;
             args.WorksheetName = worksheetName;
             args.ReadOnly = true;

--- a/src/LinqToExcel/Query/OleDbServices.cs
+++ b/src/LinqToExcel/Query/OleDbServices.cs
@@ -1,0 +1,58 @@
+﻿namespace LinqToExcel.Query
+{
+    /// <summary>
+    /// Describes which services the OLE DB connection will use.
+    /// </summary>
+    /// <remarks>
+    /// This allows you to change the OLE DB Services value in the connection string, which among other
+    /// features, will allow you to opt out of implicit transactions (e.g. those created using
+    /// TransactionScope).
+    ///
+    /// <code>
+    /// Services enabled                                | Value in connection string
+    /// ============================================================================
+    /// All services (the default)                      | "OLE DB Services = -1;"
+    /// All services except pooling                     | "OLE DB Services = -2;"
+    /// All services except pooling and auto-enlistment | "OLE DB Services = -4;"
+    /// All services except client cursor               | "OLE DB Services = -5;"
+    /// All services except client cursor and pooling   | "OLE DB Services = -6;"
+    /// No services                                     | "OLE DB Services = 0;"
+    /// </code>
+    ///
+    /// See https://msdn.microsoft.com/en-us/library/ms810829.aspx for more information.
+    /// </remarks>
+    public enum OleDbServices
+    {
+        /// <summary>
+        /// This is the default value for OLE DB Services in connection strings where it
+        /// is not explicitly specified. Sets OLE DB Services to -1 in the connection string.
+        /// </summary>
+        AllServices = -1,
+
+        /// <summary>
+        /// Sets OLE DB Services to -2 in the connection string.
+        /// </summary>
+        AllServicesExceptPooling = -2,
+
+        /// <summary>
+        /// This will disable auto-enlistment in TransactionScope.
+        /// Sets OLE DB Services to -4 in the connection string.
+        /// </summary>
+        AllServicesExceptPoolingAndAutoEnlistment = -4,
+
+        /// <summary>
+        /// Sets OLE DB Services to -5 in the connection string.
+        /// </summary>
+        AllServicesExceptClientCursor = -5,
+
+        /// <summary>
+        /// Sets OLE DB Services to -6 in the connection string.
+        /// </summary>
+        AllServicesExceptClientCursorAndPooling = -6,
+
+        /// <summary>
+        /// Sets OLE DB Services to 0 in the connection string.
+        /// </summary>
+        NoServices = 0,
+    }
+}


### PR DESCRIPTION
If you happen to query LinqToExcel while inside an open `TransactionScope`, the OLEDB provider will fail because it can't enlist in distributed transactions.

This PR retains that behavior as default, but provides a way to opt out of `TransactionScope` enlistment by a configuration setting:

```c#
excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
```

### Motivation

We are using LinqToExcel in a custom import/export tool and we wrapped a testing framework around the whole thing. Part of that testing framework involved wrapping entire tests in a `TransactionScope` context so that it could all be rolled back when the test completes. Adding the ability to suppress LinqToExcel from enlisting in the `TransactionScope` was thus required.