### PR TITLE
Allow lazy queries using yield statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,3 +291,17 @@ Set the `ReadOnly` property to true to open the file in readonly mode. The defau
 var excel = new ExcelQueryFactory("excelFileName");
 excel.ReadOnly = true;
 ```
+
+## Lazy Mode
+
+Set the `Lazy` property to true to read rows one at a time instead of pulling everything into memory at once. Under the
+hood, this is accomplished using C# `yield` statements.
+
+If you read lazily, you will want to make sure you dispose of the `IEnumerator<T>` when finished. C# will do this
+automatically for you in `foreach` statements and most, if not all, LINQ statements (e.g. `FirstOrDefault()` reads the
+first row and disposes automatically).
+
+```c#
+var excel = new ExcelQueryFactory("excelFileName");
+excel.Lazy = true;
+```

--- a/src/LinqToExcel/ExcelQueryFactory.cs
+++ b/src/LinqToExcel/ExcelQueryFactory.cs
@@ -46,6 +46,13 @@ namespace LinqToExcel
         /// </summary>
         public bool UsePersistentConnection { get; set; }
 
+        /// <summary>
+        /// If true, the query engine iterates a row at a time.
+        /// If false, the entire query is read into a List.
+        /// Default is false
+        /// </summary>
+        public bool Lazy { get; set; }
+
         public ExcelQueryFactory()
           : this(null, null) { }
 
@@ -209,7 +216,8 @@ namespace LinqToExcel
                 Transformations = _transformations,
                 UsePersistentConnection = UsePersistentConnection,
                 TrimSpaces = TrimSpaces,
-                ReadOnly = ReadOnly
+                ReadOnly = ReadOnly,
+                Lazy = Lazy,
             };
         }
 

--- a/src/LinqToExcel/Query/ExcelQueryArgs.cs
+++ b/src/LinqToExcel/Query/ExcelQueryArgs.cs
@@ -23,6 +23,7 @@ namespace LinqToExcel.Query
         internal bool UsePersistentConnection { get; set; }
 		internal OleDbConnection PersistentConnection { get; set; }
         internal TrimSpacesType TrimSpaces { get; set; }
+        internal bool Lazy { get; set; }
 
         internal ExcelQueryArgs()
             : this(new ExcelQueryConstructorArgs())
@@ -37,6 +38,7 @@ namespace LinqToExcel.Query
             UsePersistentConnection = args.UsePersistentConnection;
             TrimSpaces = args.TrimSpaces;
             ReadOnly = args.ReadOnly;
+            Lazy = args.Lazy;
         }
 
         public override string ToString()

--- a/src/LinqToExcel/Query/ExcelQueryConstructorArgs.cs
+++ b/src/LinqToExcel/Query/ExcelQueryConstructorArgs.cs
@@ -9,6 +9,7 @@ namespace LinqToExcel.Query
 {
     internal class ExcelQueryConstructorArgs
     {
+        internal bool Lazy { get; set; }
         internal string FileName { get; set; }
         internal Dictionary<string, string> ColumnMappings { get; set; }
         internal Dictionary<string, Func<string, object>> Transformations { get; set; }

--- a/src/LinqToExcel/Query/ExcelQueryExecutor.cs
+++ b/src/LinqToExcel/Query/ExcelQueryExecutor.cs
@@ -96,9 +96,12 @@ namespace LinqToExcel.Query
             var sql = GetSqlStatement(queryModel);
             LogSqlStatement(sql);
 
-            var objectResults = GetDataResults(sql, queryModel);
-            var projector = GetSelectProjector<T>(objectResults.FirstOrDefault(), queryModel);
-            var returnResults = objectResults.Cast<T>(projector);
+            IEnumerable<T> returnResults = Project<T>(queryModel, sql);
+
+            if (!_args.Lazy)
+            {
+                returnResults = returnResults.ToList();
+            }
 
             foreach (var resultOperator in queryModel.ResultOperators)
             {
@@ -109,6 +112,22 @@ namespace LinqToExcel.Query
             }
 
             return returnResults;
+        }
+
+        private IEnumerable<T> Project<T>(QueryModel queryModel, SqlParts sql)
+        {
+            Func<object, T> projector = null;
+
+            var objectResults = GetDataResults(sql, queryModel);
+            foreach (var row in objectResults)
+            {
+                if (projector == null)
+                {
+                    projector = GetSelectProjector<T>(row, queryModel);
+                }
+
+                yield return projector(row);
+            }
         }
 
         protected Func<object, T> GetSelectProjector<T>(object firstResult, QueryModel queryModel)
@@ -206,6 +225,11 @@ namespace LinqToExcel.Query
                     results = GetRowNoHeaderResults(data);
                 else
                     results = GetTypeResults(data, columns, queryModel);
+
+                foreach (var result in results)
+                {
+                    yield return result;
+                }
             }
             finally
             {
@@ -217,8 +241,6 @@ namespace LinqToExcel.Query
                     _args.PersistentConnection = null;
                 }
             }
-
-            return results;
         }
 
         /// <summary>
@@ -258,7 +280,6 @@ namespace LinqToExcel.Query
 
         private IEnumerable<object> GetRowResults(IDataReader data, IEnumerable<string> columns)
         {
-            var results = new List<object>();
             var columnIndexMapping = new Dictionary<string, int>();
             for (var i = 0; i < columns.Count(); i++)
                 columnIndexMapping[columns.ElementAt(i)] = i;
@@ -281,14 +302,12 @@ namespace LinqToExcel.Query
                         throw new Exceptions.ExcelException(currentRowNumber, i, columns.ElementAtOrDefault(i), exception);
                     }
                 }
-                results.CallMethod("Add", new Row(cells, columnIndexMapping));
+                yield return new Row(cells, columnIndexMapping);
             }
-            return results.AsEnumerable();
         }
 
         private IEnumerable<object> GetRowNoHeaderResults(OleDbDataReader data)
         {
-            var results = new List<object>();
             var currentRowNumber = 0;
             while (data.Read())
             {
@@ -307,14 +326,12 @@ namespace LinqToExcel.Query
                         throw new Exceptions.ExcelException(currentRowNumber, i, exception);
                     }
                 }
-                results.CallMethod("Add", new RowNoHeader(cells));
+                yield return new RowNoHeader(cells);
             }
-            return results.AsEnumerable();
         }
 
         private IEnumerable<object> GetTypeResults(IDataReader data, IEnumerable<string> columns, QueryModel queryModel)
         {
-            var results = new List<object>();
             var fromType = queryModel.MainFromClause.ItemType;
             var props = fromType.GetProperties();
             if (_args.StrictMapping.Value != StrictMappingType.None)
@@ -365,9 +382,8 @@ namespace LinqToExcel.Query
                         }
                     }
                 }
-                results.Add(result);
+                yield return result;
             }
-            return results.AsEnumerable();
         }
 
         /// <summary>


### PR DESCRIPTION
This converts the core row traversal mechanism to use C# `yield` statements rather than reading the entire dataset into memory at once using `ToList()`.

The default behavior hasn't changed. You have to opt into the lazy reading functionality by setting

```c#
excel.Lazy = true;
```

Reading lazily can offer significant performance improvements on large datasets, especially when queries do not span the entire dataset.