### PR TITLE
Add means to gather exceptions instead of throwing

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,3 +291,14 @@ Set the `ReadOnly` property to true to open the file in readonly mode. The defau
 var excel = new ExcelQueryFactory("excelFileName");
 excel.ReadOnly = true;
 ```
+
+## Continuing on Type Conversion Errors
+
+When mapping a field to a type, if there is a type conversion error, an exception is thrown. You can overcome the
+default exception throwing behavior by implementing the `IAllowFieldTypeConversionExceptions` interface on your class.
+Any class that implements this interface must carry a non-null list of `ExcelException` in `FieldTypeConversionExceptions`.
+If any exceptions occur during the field type conversion, it will be added to this list rather than thrown.
+
+Note that you should check the exceptions list before accessing any values on your strongly typed row, since any
+fields listed in the exception list will be in an indeterminate state.
+

--- a/src/LinqToExcel.Tests/CompanyBadWithAllowFieldTypeConversionExceptions.cs
+++ b/src/LinqToExcel.Tests/CompanyBadWithAllowFieldTypeConversionExceptions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using LinqToExcel.Exceptions;
+
+namespace LinqToExcel.Tests
+{
+    class CompanyBadWithAllowFieldTypeConversionExceptions : IAllowFieldTypeConversionExceptions
+    {
+        public CompanyBadWithAllowFieldTypeConversionExceptions()
+        {
+            FieldTypeConversionExceptions = new List<ExcelException>();
+        }
+
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The CEO column is actually a string and should fail type conversion to int.
+        /// </summary>
+        public int CEO { get; set; }
+
+        /// <summary>
+        /// The EmployeeCount column is actually a string and should fail type conversion to DateTime.
+        /// </summary>
+        public DateTime EmployeeCount { get; set; }
+
+        public IList<ExcelException> FieldTypeConversionExceptions { get; private set; }
+    }
+}

--- a/src/LinqToExcel.Tests/CompanyGoodWithAllowFieldTypeConversionExceptions.cs
+++ b/src/LinqToExcel.Tests/CompanyGoodWithAllowFieldTypeConversionExceptions.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using LinqToExcel.Exceptions;
+
+namespace LinqToExcel.Tests
+{
+    class CompanyGoodWithAllowFieldTypeConversionExceptions : IAllowFieldTypeConversionExceptions
+    {
+        public CompanyGoodWithAllowFieldTypeConversionExceptions()
+        {
+            FieldTypeConversionExceptions = new List<ExcelException>();
+        }
+
+        public string Name { get; set; }
+        public string CEO { get; set; }
+        public int EmployeeCount { get; set; }
+
+        public IList<ExcelException> FieldTypeConversionExceptions { get; private set; }
+    }
+}

--- a/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
+++ b/src/LinqToExcel.Tests/ExcelQueryFactoryTests.cs
@@ -304,6 +304,44 @@ namespace LinqToExcel.Tests
         }
 
         [Test]
+        public void IAllowFieldTypeConversionExceptions_NoExceptionsWhenFieldsAreGood()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName, new LogManagerFactory());
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<CompanyGoodWithAllowFieldTypeConversionExceptions>()
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+
+            var company = companies[0];
+            Assert.AreEqual("ACME", company.Name);
+            Assert.AreEqual("Bugs Bunny", company.CEO);
+            Assert.AreEqual(25, company.EmployeeCount);
+            Assert.AreEqual(0, company.FieldTypeConversionExceptions.Count);
+        }
+
+        [Test]
+        public void IAllowFieldTypeConversionExceptions_GathersExceptions()
+        {
+            var excel = new ExcelQueryFactory(_excelFileName, new LogManagerFactory());
+            excel.AddMapping<Company>(x => x.IsActive, "Active");
+
+            var companies = (from c in excel.Worksheet<CompanyBadWithAllowFieldTypeConversionExceptions>()
+                             where c.Name == "ACME"
+                             select c).ToList();
+
+            Assert.AreEqual(1, companies.Count);
+
+            var company = companies[0];
+            Assert.AreEqual("ACME", company.Name);
+            Assert.AreEqual(2, company.FieldTypeConversionExceptions.Count);
+            Assert.AreEqual("CEO", company.FieldTypeConversionExceptions[0].ColumnName);
+            Assert.AreEqual("EmployeeCount", company.FieldTypeConversionExceptions[1].ColumnName);
+        }
+
+        [Test]
         public void TrimSpaces_Start_TrimsWhiteSpacesAtTheBeginning()
         {
             var excel = new ExcelQueryFactory(_excelFileName, new LogManagerFactory());

--- a/src/LinqToExcel/Domain/IAllowFieldTypeConversionExceptions.cs
+++ b/src/LinqToExcel/Domain/IAllowFieldTypeConversionExceptions.cs
@@ -1,0 +1,16 @@
+﻿using LinqToExcel.Exceptions;
+using System.Collections.Generic;
+
+namespace LinqToExcel
+{
+    /// <summary>
+    /// Implement this interface to bypass the default thrown exception
+    /// on a field parse error. All exceptions will instead be placed in
+    /// this list. Be aware that you will still get a typed row back but
+    /// failed column values should be untrusted.
+    /// </summary>
+    public interface IAllowFieldTypeConversionExceptions
+    {
+        IList<ExcelException> FieldTypeConversionExceptions { get; }
+    }
+}


### PR DESCRIPTION
This offers a way to continue on type conversion errors. If you opt in (by implementing `IAllowFieldTypeConversionExceptions`), those conversion exceptions will be collected in a list per row rather than thrown.

### Motivation

We have a large import/export process that needed to be tolerant of some bad data while importing good rows. This allows us to continue processing an import that has bad data in some of its rows, and we can later give the user an indication of which rows failed and why.