### PR TITLE
- implemented Source Link for easier debugging

### DIFF
--- a/src/LinqToExcel/LinqToExcel.csproj
+++ b/src/LinqToExcel/LinqToExcel.csproj
@@ -18,10 +18,19 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>LinqToExcel.snk</AssemblyOriginatorKeyFile>
     <RepositoryUrl>https://github.com/paulyoder/LinqToExcel</RepositoryUrl>
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+
+    <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+
+    <!-- Optional: Include the PDB in the built .nupkg -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Remotion.Linq" Version="[2.1.2,2.2)" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
this change adds PDB to NuGet package and [adds Source Link ](https://blog.nuget.org/20180827/Introducing-Source-Code-Link-for-NuGet-packages.html)JSON data to PDB to fetch the file during debugging from github