### PR TITLE
Csv encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,11 @@ See [Pooling in the Microsoft Data Access
 Components](https://msdn.microsoft.com/en-us/library/ms810829.aspx#Troubleshooting%20MDAC%20Pooling) for more
 information.
 
+```c#
+var excel = new ExcelQueryFactory("excelFileName");
+excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
+```
+
 ## Encoding
 
 If the file is in a different encoding use the CodePageIdentifer so the setting is passed to the engine.
@@ -335,6 +340,6 @@ listing of Code Page Identifiers and their corresponding encoding.
 
 ```c#
 var excel = new ExcelQueryFactory("excelFileName");
-excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;
+//Set the encoding to UTF-8
+excel.CodePageIdentifier = 65001;
 ```
-

--- a/README.md
+++ b/README.md
@@ -326,6 +326,13 @@ See [Pooling in the Microsoft Data Access
 Components](https://msdn.microsoft.com/en-us/library/ms810829.aspx#Troubleshooting%20MDAC%20Pooling) for more
 information.
 
+## Encoding
+
+If the file is in a different encoding use the CodePageIdentifer so the setting is passed to the engine.
+
+See [Code Page Identifiers](https://docs.microsoft.com/en-us/windows/desktop/intl/code-page-identifiers) for a complete 
+listing of Code Page Identifiers and their corresponding encoding.
+
 ```c#
 var excel = new ExcelQueryFactory("excelFileName");
 excel.OleDbServices = Query.OleDbServices.AllServicesExceptPoolingAndAutoEnlistment;

--- a/src/LinqToExcel.v3.ncrunchsolution.user
+++ b/src/LinqToExcel.v3.ncrunchsolution.user
@@ -1,0 +1,5 @@
+﻿<SolutionConfiguration>
+  <Settings>
+    <CurrentEngineMode>Run all tests automatically [Global]</CurrentEngineMode>
+  </Settings>
+</SolutionConfiguration>

--- a/src/LinqToExcel.v3.ncrunchsolution.user
+++ b/src/LinqToExcel.v3.ncrunchsolution.user
@@ -1,5 +1,0 @@
-﻿<SolutionConfiguration>
-  <Settings>
-    <CurrentEngineMode>Run all tests automatically [Global]</CurrentEngineMode>
-  </Settings>
-</SolutionConfiguration>

--- a/src/LinqToExcel/ExcelQueryFactory.cs
+++ b/src/LinqToExcel/ExcelQueryFactory.cs
@@ -58,6 +58,11 @@ namespace LinqToExcel
         /// </summary>
         public OleDbServices OleDbServices { get; set; }
 
+        /// <summary>
+        /// Gets or set the value of the Code Page Identifier
+        /// </summary>
+        public int? CodePageIdentifier { get; set; }
+
         public ExcelQueryFactory()
           : this(null, null) { }
 
@@ -225,6 +230,7 @@ namespace LinqToExcel
                 ReadOnly = ReadOnly,
                 Lazy = Lazy,
                 OleDbServices = OleDbServices,
+                CodePageIdentifier = CodePageIdentifier ?? 0
             };
         }
 

--- a/src/LinqToExcel/ExcelQueryFactory.cs
+++ b/src/LinqToExcel/ExcelQueryFactory.cs
@@ -59,7 +59,9 @@ namespace LinqToExcel
         public OleDbServices OleDbServices { get; set; }
 
         /// <summary>
-        /// Gets or set the value of the Code Page Identifier
+        /// Gets or sets the value of the Code Page Identifier sent in the connection strings,
+        /// this allows for files with different encodings. For the full
+        /// list see https://docs.microsoft.com/en-us/windows/desktop/intl/code-page-identifiers
         /// </summary>
         public int? CodePageIdentifier { get; set; }
 

--- a/src/LinqToExcel/Query/ExcelQueryArgs.cs
+++ b/src/LinqToExcel/Query/ExcelQueryArgs.cs
@@ -25,6 +25,7 @@ namespace LinqToExcel.Query
         internal TrimSpacesType TrimSpaces { get; set; }
         internal bool Lazy { get; set; }
         internal OleDbServices OleDbServices { get; set; }
+        internal int CodePageIdentifier { get; set; }
 
         internal ExcelQueryArgs()
             : this(new ExcelQueryConstructorArgs())
@@ -54,6 +55,7 @@ namespace LinqToExcel.Query
                 PersistentConnection = orig.PersistentConnection;
                 TrimSpaces = orig.TrimSpaces;
                 OleDbServices = orig.OleDbServices;
+                CodePageIdentifier = orig.CodePageIdentifier;
             }
         }
 
@@ -68,6 +70,7 @@ namespace LinqToExcel.Query
             ReadOnly = args.ReadOnly;
             Lazy = args.Lazy;
             OleDbServices = args.OleDbServices;
+            CodePageIdentifier = args.CodePageIdentifier;
         }
 
         public override string ToString()

--- a/src/LinqToExcel/Query/ExcelQueryConstructorArgs.cs
+++ b/src/LinqToExcel/Query/ExcelQueryConstructorArgs.cs
@@ -24,5 +24,6 @@ namespace LinqToExcel.Query
         internal TrimSpacesType TrimSpaces { get; set; }
         internal bool ReadOnly { get; set; }
         internal OleDbServices OleDbServices { get; set; }
+        internal int CodePageIdentifier { get; set; }
     }
 }

--- a/src/LinqToExcel/Query/ExcelUtilities.cs
+++ b/src/LinqToExcel/Query/ExcelUtilities.cs
@@ -36,7 +36,7 @@ namespace LinqToExcel.Query
                 connString = string.Format(
                     @"Provider=Microsoft.ACE.OLEDB.12.0;Data Source={0};OLE DB Services={1:d};Extended Properties=""text;Excel 12.0;HDR=YES;IMEX=1""",
                     Path.GetDirectoryName(args.FileName),
-                    args.OleDbServices);
+                    args.OleDbServices);                
             }
             else
             {
@@ -51,6 +51,9 @@ namespace LinqToExcel.Query
 
             if (args.ReadOnly)
                 connString = connString.Replace("IMEX=1", "IMEX=1;READONLY=TRUE");
+
+            if(args.CodePageIdentifier > 0)
+                connString = connString.Replace("IMEX=1",string.Format ("IMEX=1;CharacterSet={0:000}",args.CodePageIdentifier));
 
             return connString;
         }


### PR DESCRIPTION
I found the issue of the Ace engine not using the correct encoding for the CSV file I was using. 

I've put in the ability to set the Code Page Identifier from the ExcelQueryFactory so it uses the correct encoding.