### PR TITLE
Updated Packages because of EntityFrameworkCore > 2.1.0

### DIFF
--- a/src/LinqToExcel.Tests/LinqToExcel.Tests.csproj
+++ b/src/LinqToExcel.Tests/LinqToExcel.Tests.csproj
@@ -7,11 +7,11 @@
 
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
-    <PackageReference Include="NUnit" Version="3.10.1" />
-    <PackageReference Include="NUnit.Console" Version="3.8.0" />
-    <PackageReference Include="NUnit.ConsoleRunner" Version="3.8.0" />
+    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit.Console" Version="3.9.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.9.0" />
     <PackageReference Include="NUnit.Extension.VSProjectLoader" Version="3.8.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 
   <!-- Run tests for .Net 3.5 in x64 mode, by default -->

--- a/src/LinqToExcel/LinqToExcel.csproj
+++ b/src/LinqToExcel/LinqToExcel.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Remotion.Linq" Version="[2.1.2,2.2)" />
+    <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Since EntityFrameworkCore is stable since 10 months, Remotion.Linq should be updated to 2.2.0 in LinqToExcel. Otherwise it's not usable with EFCore > 2.1.0

Also updated NUnit-Framework.

For each .Net Framework version, 5 Unit-tests fails because of incorrect filepath to Desktop.