### PR TITLE
Fixed case where UnmappedCells is null

### DIFF
--- a/src/LinqToExcel.Tests/CompanyNameWithUnmappedCells.cs
+++ b/src/LinqToExcel.Tests/CompanyNameWithUnmappedCells.cs
@@ -11,6 +11,6 @@ namespace LinqToExcel.Tests
 		}
 
 		public string Name { get; set; }
-		public IDictionary<string, Cell> UnmappedCells { get; private set; }
+		public IDictionary<string, Cell> UnmappedCells { get; set; }
 	}
 }

--- a/src/LinqToExcel/Domain/IContainsUnmappedCells.cs
+++ b/src/LinqToExcel/Domain/IContainsUnmappedCells.cs
@@ -8,6 +8,6 @@ namespace LinqToExcel
 	/// </summary>
 	public interface IContainsUnmappedCells
 	{
-		IDictionary<string, Cell> UnmappedCells { get; }
+		IDictionary<string, Cell> UnmappedCells { get; set; }
 	}
 }

--- a/src/LinqToExcel/Query/ExcelQueryExecutor.cs
+++ b/src/LinqToExcel/Query/ExcelQueryExecutor.cs
@@ -405,7 +405,9 @@ namespace LinqToExcel.Query
                 if (gatherUnmappedCells)
                 {
                     var gatherer = (IContainsUnmappedCells)result;
-                    if (gatherer.UnmappedCells != null)
+                    if(gatherer != null && gatherer.UnmappedCells == null)
+                        gatherer.UnmappedCells = new Dictionary<string, Cell>();
+                    if (gatherer != null)
                     {
                         foreach (var col in columns.Except(propMapping.Select(x => x.columnName)))
                         {


### PR DESCRIPTION
There are two changes in this PR:

1. If the class implements IContainsUnmappedCells, then initialize the collection UnmappedCells, so the user has to only implement the interface. Otherwise, the user would have to create a constructor and initialize the dictionary in there, which you realize you have to do only if you pull the source code and debug through it.
2. Allow a setter on the UnmappedCells dictionary for situations where you would want to serialize the object but without the UnmappedCells. In this case, you can set UnmappedCells to null, and tell the serializer to ignore null values. If you think this is not such a common scenario, I can remove this change.